### PR TITLE
Add opinion to automatically configure Github Packages repository when running on Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ plugins {
  * The `org.ajoberstar.reckon` plugin: Is configured with `scopeFromProp()` and `snapshotFromProp()`. Before a tag can be created with `reckonTagCreate`, the `check` task must complete succesfully.
  * All `Test`-type tasks are configured in fail-fast mode when a CI environment is detected
  * The `check` task depends on all tasks of type `Test`
+ * The `maven-publish` and `be.vbgn.ci-detect` plugins, running on Github Actions and the `GITHUB_TOKEN` environment variable is available: Automatically configure a publication repository named `GithubPackages`.

--- a/src/main/groovy/be/vbgn/gradle/devconventions/conventions/impl/AutomaticallyPublishToGithubPackagesOpinion.groovy
+++ b/src/main/groovy/be/vbgn/gradle/devconventions/conventions/impl/AutomaticallyPublishToGithubPackagesOpinion.groovy
@@ -1,0 +1,53 @@
+package be.vbgn.gradle.devconventions.conventions.impl
+
+import be.vbgn.gradle.devconventions.conventions.Opinion
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+
+class AutomaticallyPublishToGithubPackagesOpinion implements Opinion {
+    private static final Logger LOGGER = Logging.getLogger(AutomaticallyPublishToGithubPackagesOpinion.class)
+
+    @Override
+    void apply(Project project) {
+        project.plugins.withType(MavenPublishPlugin.class) {
+            project.getPlugins().withId("be.vbgn.ci-detect") {
+                project.extensions.configure(PublishingExtension.class) {
+                    if (project.ci.isCi() && project.ci.platform == "GithubActions") {
+                        configureRepository(it)
+                    }
+                }
+            }
+        }
+    }
+
+    private void configureRepository(PublishingExtension publishingExtension) {
+        String githubActor = System.getenv("GITHUB_ACTOR")
+        String githubToken = System.getenv("GITHUB_TOKEN")
+        String githubRepo = System.getenv("GITHUB_REPOSITORY")
+
+        LOGGER.debug("GITHUB_REPOSITORY={}; GITHUB_ACTOR={}", githubRepo, githubActor)
+
+        if (!githubRepo || !githubActor) {
+            return;
+        }
+
+        if (!githubToken) {
+            LOGGER.warn("Github Actions CI was detected, but GITHUB_TOKEN is missing. Automatic configuration of publishing is not possible.")
+            return;
+        }
+
+        publishingExtension.repositories {
+            maven {
+                name = "GithubPackages"
+                url = "https://maven.pkg.github.com/${githubRepo.toLowerCase()}"
+                credentials {
+                    username = githubActor
+                    password = githubToken
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We have pretty much all the necessary configuration to publish our artifacts to Github Packages when we are running on Github Actions. Let's make publication easier.
