### PR TITLE
Stop publishing and consuming packages from GH packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
         run: ./gradlew sonarqube -Dsonar.projectKey=vierbergenlars_dev-conventions-gradle-plugin -Dsonar.organization=vierbergenlars-github -Dsonar.host.url=https://sonarcloud.io
-      - name: Publish to Github Packages
-        if: ${{ github.ref == 'refs/heads/master' }} # Only publish a snapshot from the master branch
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: ./gradlew publishAllPublicationsToGithubPackagesRepository --info
       - name: Publish plugin
         if: ${{ github.event_name == 'release' }}
         env:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,30 +1,3 @@
-pluginManagement {
-    if (System.getenv("GITHUB_TOKEN")) {
-        // Configure a custom repository when running on github actions
-        repositories {
-            maven {
-                url = "https://maven.pkg.github.com/vierbergenlars/dev-conventions-gradle-plugin"
-                credentials {
-                    username = System.getenv("GITHUB_ACTOR")
-                    password = System.getenv("GITHUB_TOKEN")
-                }
-            }
-            gradlePluginPortal()
-        }
-        // Replace dev-conventions plugins with the snapshot version
-        resolutionStrategy {
-            eachPlugin {
-                if (requested.id.id.startsWith("be.vbgn.dev-conventions")) {
-                    // Split current version, bump minor version, as reckon does by default to determine snapshot version
-                    String[] versionParts = requested.version.split("\\.")
-                    versionParts[1] = (versionParts[1].toInteger() + 1).toString()
-                    useVersion(versionParts.join(".") + "-SNAPSHOT")
-                    settings.gradle.rootProject.logger.lifecycle("Adjusted plugin version: id '" + target.id.id + "' version '" + target.version + "'")
-                }
-            }
-        }
-    }
-}
 rootProject.name = 'dev-conventions-plugin'
 
 include ':fake-ci-detect'


### PR DESCRIPTION
Using a snapshot version for the next release does not seem to work out properly in practice