### PR TITLE
Run release workflow when a release is published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 on:
   push:
-    branches:
-    tags:
   pull_request:
+  release:
+    types:
+      - published
   schedule:
     - cron: '0 0 * * 1'
 


### PR DESCRIPTION
It appears that when creating tags & releases from github, that the push
tag event is not triggered.