### PR TITLE
Update ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 on:
   push:
+    branches:
+      - master
+    tags:
+      - v*
   pull_request:
-  release:
-    types:
-      - published
   schedule:
     - cron: '0 0 * * 1'
 
@@ -23,6 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./gradlew check
       - name: Upload analysis to sonarcloud
+        if: "${{ env.SONAR_TOKEN != '' }}"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
* Only submit to sonarcloud if the sonar token is available
* Only build for master branch and version tags, other contributions happen via PRs anyways.