### PR TITLE
Trigger a release build when a release is published.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - master
-    tags:
-      - v*
+  release:
+    types:
+      - published
   pull_request:
   schedule:
     - cron: '0 0 * * 1'


### PR DESCRIPTION
When creating tags via a release created by a bot, the tags workflow is not triggered.