### PR TITLE
Create service loader manually

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
     id 'org.ajoberstar.reckon' version '0.13.1'
     id 'org.sonarqube' version '3.3'
     id "com.gradle.plugin-publish" version "0.18.0"
-    id "com.github.harbby.gradle.serviceloader" version "1.1.5"
     id 'nebula.integtest' version '9.2.2'
     id 'be.vbgn.dev-conventions.opinion' version '0.5.0'
     id 'be.vbgn.ci-detect' version '0.5.0'
@@ -75,16 +74,3 @@ pluginBundle {
     }
 }
 
-serviceLoader {
-    serviceInterface "be.vbgn.gradle.devconventions.conventions.Convention"
-    serviceInterface "be.vbgn.gradle.devconventions.conventions.Opinion"
-}
-tasks.named('serviceLoaderBuild').configure {
-    inputs.files(sourceSets.main.output.classesDirs)
-    inputs.property("serviceInterfaces", serviceLoader.serviceInterfaces)
-    outputs.dir(sourceSets.main.output.resourcesDir.toString() + "/META-INF/services")
-}
-classes.finalizedBy("serviceLoaderBuild")
-tasks.withType(Test).configureEach {
-    dependsOn("serviceLoaderBuild")
-}

--- a/src/main/resources/META-INF/services/be.vbgn.gradle.devconventions.conventions.Convention
+++ b/src/main/resources/META-INF/services/be.vbgn.gradle.devconventions.conventions.Convention
@@ -1,0 +1,4 @@
+be.vbgn.gradle.devconventions.conventions.impl.SonarqubeCiDetectConvention
+be.vbgn.gradle.devconventions.conventions.impl.ParallelTestsConvention
+be.vbgn.gradle.devconventions.conventions.impl.JacocoSonarqubeConvention
+be.vbgn.gradle.devconventions.conventions.impl.AllTestsWithCoverageConvention

--- a/src/main/resources/META-INF/services/be.vbgn.gradle.devconventions.conventions.Opinion
+++ b/src/main/resources/META-INF/services/be.vbgn.gradle.devconventions.conventions.Opinion
@@ -1,0 +1,4 @@
+be.vbgn.gradle.devconventions.conventions.impl.TestsFailFastOnCIOpinion
+be.vbgn.gradle.devconventions.conventions.impl.ReckonOpinion
+be.vbgn.gradle.devconventions.conventions.impl.CheckDependsOnAllTestsOpinion
+be.vbgn.gradle.devconventions.conventions.impl.AutomaticallyPublishToGithubPackagesOpinion


### PR DESCRIPTION
The harbby service loader plugin appears to be no longer open source,
and it also messes with up-to-date checks for compile tasks.