### PR TITLE
Check for the JavaBasePlugin being applied instead of java plugin

### DIFF
--- a/src/integTest/java/be/vbgn/gradle/devconventions/integration/AllTestsWithCoverageConventionTest.java
+++ b/src/integTest/java/be/vbgn/gradle/devconventions/integration/AllTestsWithCoverageConventionTest.java
@@ -13,6 +13,14 @@ public class AllTestsWithCoverageConventionTest extends AbstractIntegrationTest 
     }
 
     @Test
+    public void conventionConfiguresJacocoWithJavaLibrary() throws IOException {
+        createGradleRunner(
+                integrationTests.resolve("AllTestsWithCoverageConvention/conventionConfiguresJacocoWithJavaLibrary"))
+                .withArguments("jacocoTestReport", "jacocoIntegrationTestReport")
+                .build();
+    }
+
+    @Test
     public void conventionConfiguresJacocoWithoutJava() throws IOException {
         createGradleRunner(
                 integrationTests.resolve("AllTestsWithCoverageConvention/conventionConfiguresJacocoWithoutJava"))

--- a/src/integTest/resources/be/vbgn/gradle/devconventions/integration/AllTestsWithCoverageConvention/conventionConfiguresJacocoWithJavaLibrary/build.gradle
+++ b/src/integTest/resources/be/vbgn/gradle/devconventions/integration/AllTestsWithCoverageConvention/conventionConfiguresJacocoWithJavaLibrary/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id "jacoco"
+    id "be.vbgn.dev-conventions"
+    id "java-library"
+}
+
+task integrationTest(type: Test) {
+}
+
+
+jacocoTestReport {
+    doLast {
+        assert jacocoTestReport.executionData.size() == 1
+    }
+}
+
+jacocoIntegrationTestReport {
+    doLast {
+        assert jacocoIntegrationTestReport.executionData.size() == 1
+    }
+}

--- a/src/main/groovy/be/vbgn/gradle/devconventions/conventions/impl/AllTestsWithCoverageConvention.java
+++ b/src/main/groovy/be/vbgn/gradle/devconventions/conventions/impl/AllTestsWithCoverageConvention.java
@@ -2,6 +2,7 @@ package be.vbgn.gradle.devconventions.conventions.impl;
 
 import be.vbgn.gradle.devconventions.conventions.Convention;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskCollection;
@@ -21,7 +22,7 @@ public class AllTestsWithCoverageConvention implements Convention {
 
             testTasks.all(testTask -> {
                 // Do not configure test task with jacoco, as that is already done by the jacoco plugin itself
-                if (project.getPlugins().hasPlugin("java") && testTask.getName().equals("test")) {
+                if (project.getPlugins().hasPlugin(JavaBasePlugin.class) && testTask.getName().equals("test")) {
                     return;
                 }
 


### PR DESCRIPTION
The Test task is created in the Java plugin. java-library also applies
the Java plugin.

However, due to a quirk in the PluginManager, hasPlugin() may return
false until after a plugin has finished applying.

Fixes #38