### PR TITLE
Update reckon to version that references a static grgit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'jacoco'
     id 'maven-publish'
-    id 'org.ajoberstar.reckon' version '0.13.1'
+    id 'org.ajoberstar.reckon' version '0.13.2'
     id 'org.sonarqube' version '3.3'
     id "com.gradle.plugin-publish" version "0.20.0"
     id 'nebula.integtest' version '9.3.0'

--- a/src/integTest/resources/be/vbgn/gradle/devconventions/integration/ReckonOpinion/conventionDoesNotConfigureReckon/build.gradle
+++ b/src/integTest/resources/be/vbgn/gradle/devconventions/integration/ReckonOpinion/conventionDoesNotConfigureReckon/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.ajoberstar.reckon" version "0.13.0"
+    id "org.ajoberstar.reckon" version "0.13.2"
     id "be.vbgn.dev-conventions"
 }
 

--- a/src/integTest/resources/be/vbgn/gradle/devconventions/integration/ReckonOpinion/opinionConfiguresReckon/build.gradle
+++ b/src/integTest/resources/be/vbgn/gradle/devconventions/integration/ReckonOpinion/opinionConfiguresReckon/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "lifecycle-base"
-    id "org.ajoberstar.reckon" version "0.13.0"
+    id "org.ajoberstar.reckon" version "0.13.2"
     id "be.vbgn.dev-conventions.opinion"
 }
 


### PR DESCRIPTION
This avoids breakage of newer grgit versions on this old Gradle version
